### PR TITLE
Revert to non-Christmas images

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://tokerreines.github.io/cornyCollection/">
     <link rel="preload" as="image" href="assets/cornyCollection.jpg">
-    <link rel="icon" type="image/png" href="assets/cornyCollection_christmas.jpg">
+    <link rel="icon" type="image/png" href="assets/cornyCollection.jpg">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Corny Collection – Festband med blæs og fuld sound i København</title>
@@ -81,7 +81,7 @@
     
         <!-- Image Content -->
         <div class="md:w-1/2 mt-8 md:mt-0 flex justify-center">
-            <img src="assets/cornyCollection_christmas.jpg" alt="Corny Collection – festband spiller live med blæs og fuld sound i København" class="w-3/4">
+            <img src="assets/cornyCollection.jpg" alt="Corny Collection – festband spiller live med blæs og fuld sound i København" class="w-3/4">
         </div>
     </section>
 
@@ -158,11 +158,11 @@
 
                     <script>
                     const carouselData = [
-                        { src: 'assets/mathias_christmas.jpg', alt: 'Mathias på tuba', name: 'Mathias', caption: 'Tuba. Med højt humør og en pulserende bas holder han toget kørende. Ingen fest uden Mathias.' },
-                        { src: 'assets/nikolaj_christmas.jpg', alt: 'Nikolaj på trommer', name: 'Nikolaj', caption: 'Trommer. Disker op med usynlige temposkift og vilde grooves, når gryderne koger.' },
-                        { src: 'assets/toke_laurits_christmas.jpg', alt: 'Toke (sax) & Laurits (trombone)', name: 'Toke & Laurits', caption: 'Altsax & trombone. Smører stemningen og lægger ekstra lag på, når det skal være lækkert!' },
-                        { src: 'assets/mikkel_stig_christmas.jpg', alt: 'Mikkel & Stig på trompet', name: 'Mikkel & Stig', caption: 'Trompet. Hovedingrediensen i vores sound - og altid klar med et skævt smil.' },
-                        { src: 'assets/jesper_christmas.jpg', alt: 'Jesper', name: 'Jesper', caption: 'Tenorsax. Får folk til at sove om dagen (anæstesiolog), men holder dem vågne hele natten med sax og batman-vibes.' },
+                        { src: 'assets/mathias.jpg', alt: 'Mathias på tuba', name: 'Mathias', caption: 'Tuba. Med højt humør og en pulserende bas holder han toget kørende. Ingen fest uden Mathias.' },
+                        { src: 'assets/nikolaj.jpg', alt: 'Nikolaj på trommer', name: 'Nikolaj', caption: 'Trommer. Disker op med usynlige temposkift og vilde grooves, når gryderne koger.' },
+                        { src: 'assets/toke_laurits.jpg', alt: 'Toke (sax) & Laurits (trombone)', name: 'Toke & Laurits', caption: 'Altsax & trombone. Smører stemningen og lægger ekstra lag på, når det skal være lækkert!' },
+                        { src: 'assets/mikkel_stig.jpg', alt: 'Mikkel & Stig på trompet', name: 'Mikkel & Stig', caption: 'Trompet. Hovedingrediensen i vores sound - og altid klar med et skævt smil.' },
+                        { src: 'assets/jesper.jpg', alt: 'Jesper', name: 'Jesper', caption: 'Tenorsax. Får folk til at sove om dagen (anæstesiolog), men holder dem vågne hele natten med sax og batman-vibes.' },
                         { src: 'assets/line.jpg', alt: 'Line', name: 'Line', caption: 'Sang. Brygger af kærligheden der binder os og publikum sammen. Synger så selv Freddie Mercury kunne tage sig et hvil.' }
                     ];
 
@@ -293,7 +293,7 @@
                 <div class="flex flex-col items-start">
                     <h3 class="text-xl font-semibold text-slate-50 mb-2">Video 1</h3>
                     <div class="w-full h-64 bg-gray-200 rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
-                        <video class="w-full h-full object-cover" controls poster="assets/cornyCollection2_christmas.jpg">
+                        <video class="w-full h-full object-cover" controls poster="assets/cornyCollection2.jpg">
                             <source src="assets/video1.mp4" type="video/mp4">
                             <source src="assets/video1.webm" type="video/webm">
                             Your browser does not support the video tag. 
@@ -321,7 +321,7 @@
 
 
         <section class="w-full h-1/2 overflow-hidden">
-            <img src="assets/cornyCollection2_christmas.jpg" alt="Publikum danser til Corny Collection festband i København" class="w-full h-2/3 object-cover">
+            <img src="assets/cornyCollection2.jpg" alt="Publikum danser til Corny Collection festband i København" class="w-full h-2/3 object-cover">
         </section>
     </main>
 


### PR DESCRIPTION
Replace all Christmas-themed image references with the standard versions (favicon, hero image, carousel member photos, video poster, and bottom image).