### PR TITLE
Embed YouTube showcase videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,29 +291,27 @@
             <div class="grid grid-cols-1 md:grid-cols-3 gap-8 w-full">
 
                 <div class="flex flex-col items-start">
-                    <h3 class="text-xl font-semibold text-slate-50 mb-2">Video 1</h3>
+                    <h3 class="text-xl font-semibold text-slate-50 mb-2">Amalies fødselsdag</h3>
                     <div class="w-full h-64 bg-gray-200 rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
-                        <video class="w-full h-full object-cover" controls poster="assets/cornyCollection2.jpg">
-                            <source src="assets/video1.mp4" type="video/mp4">
-                            <source src="assets/video1.webm" type="video/webm">
-                            Your browser does not support the video tag. 
-                            <a href="assets/video1.mp4" download class="underline text-blue-400">Download videoen</a>.
-                        </video>
+                        <iframe class="w-full h-full" src="https://www.youtube-nocookie.com/embed/t3Kc7zq_Z5w" title="Amalies fødselsdag - highlights" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                     </div>
-                    <p class="text-slate-50 mt-4 text-left">Kan du ikke se videoen? <a href="assets/video1.mp4" download class="underline text-blue-400">Download den her</a>.</p>
+                    <p class="text-slate-50 mt-4 text-left">Kan du ikke se videoen? <a href="https://youtu.be/t3Kc7zq_Z5w" target="_blank" rel="noopener noreferrer" class="underline text-blue-400">Se den på YouTube</a>.</p>
                 </div>
 
                 <div class="flex flex-col items-start">
-                    <h3 class="text-xl font-semibold text-slate-50 mb-2">Video 2</h3>
+                    <h3 class="text-xl font-semibold text-slate-50 mb-2">Bryllup</h3>
                     <div class="w-full h-64 bg-gray-200 rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
-                        <video class="w-full h-full object-cover" controls poster="assets/cornyCollection3.jpg">
-                            <source src="assets/video2.mp4" type="video/mp4">
-                            <source src="assets/video2.webm" type="video/webm">
-                            Your browser does not support the video tag. 
-                            <a href="assets/video2.mp4" download class="underline text-blue-400">Download videoen</a>.
-                        </video>
+                        <iframe class="w-full h-full" src="https://www.youtube-nocookie.com/embed/ZYj3Y2r1aUQ" title="Bryllup - highlights" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                     </div>
-                    <p class="text-slate-50 mt-4 text-left">Kan du ikke se videoen? <a href="assets/video2.mp4" download class="underline text-blue-400">Download den her</a>.</p>
+                    <p class="text-slate-50 mt-4 text-left">Kan du ikke se videoen? <a href="https://youtu.be/ZYj3Y2r1aUQ" target="_blank" rel="noopener noreferrer" class="underline text-blue-400">Se den på YouTube</a>.</p>
+                </div>
+
+                <div class="flex flex-col items-start">
+                    <h3 class="text-xl font-semibold text-slate-50 mb-2">Julevideo</h3>
+                    <div class="w-full h-64 bg-gray-200 rounded-lg overflow-hidden shadow-lg flex items-center justify-center">
+                        <iframe class="w-full h-full" src="https://www.youtube-nocookie.com/embed/KSVXTxvOdxY" title="Julevideo" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                    </div>
+                    <p class="text-slate-50 mt-4 text-left">Kan du ikke se videoen? <a href="https://youtu.be/KSVXTxvOdxY" target="_blank" rel="noopener noreferrer" class="underline text-blue-400">Se den på YouTube</a>.</p>
                 </div>
 
             </div>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <div class="md:w-1/2 text-left space-y-4 z-20">
             <h1 class="text-4xl font-bold text-gray-800 font-mono md:text-5xl lg:text-8xl">Corny Collection</h1>
             <p class="text-gray-600 text-lg ml-3">
-                Blæs, fuld sound og dansestemning. Vi spiller hits, du kender, i friske live-arrangementer med masser af energi og nærvær. Det eneste, vi behøver, er en stikkontakt og et dansegulv.
+                Er livebandet til din næste fest - bryllup, firmafest, rund fødselsdag, you name it. Blæs, fuld sound og dansestemning. Vi spiller hits, du kender, i friske live-arrangementer med masser af energi og nærvær. Det eneste, vi behøver, er en stikkontakt og et dansegulv.
             </p>
                             <!-- Left arrow -->
             <a


### PR DESCRIPTION
## Summary
- replace local placeholder video sources with the three supplied YouTube embeds
- use YouTube's privacy-enhanced `youtube-nocookie.com` embed domain
- add a third card for the Christmas promotion video

## Deployment
Targets `main`, which triggers the GitHub Pages deployment workflow.

## Validation
- GitHub Actions workflow YAML parses successfully.