### PR TITLE
Align desktop section rhythm

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
     <main class="pt-6">
 
         <!-- About Us Section -->
-        <section class="bg-stone-200 p-8 md:p-16">
+        <section class="bg-stone-200 p-8 md:min-h-[34rem] md:p-16">
             <div class="flex flex-col md:flex-row items-start sm:items-center md:items-start sm:gap-8 md:gap-16">
                 
                 <div class="sm:w-1/2 md:w-1/3 mb-6 sm:mb-0 flex justify-center sm:justify-end">
@@ -287,7 +287,7 @@
         </section>
 
         <!-- Video Section -->
-        <section class="bg-stone-600 p-8 md:p-16 flex flex-col items-start">
+        <section class="flex flex-col items-start bg-stone-600 p-8 md:min-h-[34rem] md:p-16">
             <h2 class="text-4xl font-bold text-slate-50 mb-8 text-left font-sans">Videoer</h2>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-8 w-full">
 
@@ -339,7 +339,7 @@
             </div>
         </section> -->
 
-        <section class="bg-stone-200 p-8 md:p-16">
+        <section class="bg-stone-200 p-8 md:min-h-[34rem] md:p-16">
             <div class="mb-8 max-w-2xl">
                 <h2 class="text-3xl md:text-4xl font-bold mb-3">Udtalelser</h2>
                 <p class="text-gray-700 text-lg">Kommentarer fra fester, vi har spillet til.</p>
@@ -362,11 +362,11 @@
             </div>
         </section>
 
-        <section class="bg-[#171512] py-10 text-white md:py-16">
+        <section class="bg-[#171512] py-10 text-white md:min-h-[34rem] md:py-16">
             <div class="px-8 md:px-16 mb-6">
                 <h2 class="text-3xl md:text-4xl font-bold">Udsnit af tidligere jobs</h2>
             </div>
-            <div id="jobs-gallery" class="group relative w-full aspect-[4/3] md:aspect-[16/7] overflow-hidden bg-[#171512]" aria-roledescription="billedkarrusel" aria-label="Tidligere jobs">
+            <div id="jobs-gallery" class="group relative w-full aspect-[4/3] overflow-hidden bg-[#171512] md:aspect-[16/4]" aria-roledescription="billedkarrusel" aria-label="Tidligere jobs">
                 <img id="jobs-gallery-backdrop" src="assets/jobs/line_peters_bryllup.png" alt="" aria-hidden="true" class="absolute -inset-4 h-[calc(100%+2rem)] w-[calc(100%+2rem)] scale-105 object-cover opacity-35 blur-xl transition-opacity duration-700 motion-reduce:transition-none">
                 <img id="jobs-gallery-image" src="assets/jobs/line_peters_bryllup.png" alt="Corny Collection spiller til Peter og Lines bryllup i Mårslet ved Århus" class="absolute inset-6 h-[calc(100%-3rem)] w-[calc(100%-3rem)] border border-white/10 object-contain brightness-90 contrast-125 saturate-75 shadow-[0_24px_70px_rgba(0,0,0,0.55)] transition-opacity duration-700 md:inset-10 md:h-[calc(100%-5rem)] md:w-[calc(100%-5rem)] motion-reduce:transition-none">
                 <div class="absolute inset-x-0 bottom-0 z-10 bg-black/75 px-8 py-5 text-white md:px-16 md:py-7">


### PR DESCRIPTION
## Summary
- Give the main content sections a consistent desktop minimum height.
- Use a more panoramic format for the previous-jobs gallery so it matches the surrounding section rhythm.
- Preserve content-driven heights on mobile.

## Validation
- `npm run build`
- Desktop section heights checked in browser
- Mobile overflow checked in browser